### PR TITLE
fix: correctly manage popover creation/destroy

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -15,12 +15,12 @@ export function configureButtons(bpmnVisualization) {
     document.getElementById("reset_all").addEventListener("click",  () => {
         hideHappyPath(bpmnVisualization);
         hideConformanceData(bpmnVisualization);
-        hideComplianceRules();
+        hideComplianceRules(bpmnVisualization);
     });
 
     addEventListener("happy_path", state.isHappyPathDisplayed, () => showHappyPath(bpmnVisualization), () => hideHappyPath(bpmnVisualization));
     addEventListener("conformance_data", state.isConformanceDisplayed, () => showConformanceData(bpmnVisualization), () => hideConformanceData(bpmnVisualization));
-    addEventListener("compliance_rules", state.isComplianceDisplayed, () => showComplianceRules(bpmnVisualization), () => hideComplianceRules());
+    addEventListener("compliance_rules", state.isComplianceDisplayed, () => showComplianceRules(bpmnVisualization), () => hideComplianceRules(bpmnVisualization));
 }
 
 function addEventListener(buttonId, buttonState, showCallback, hideCallback){

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const mainBpmnVisualization = new BpmnVisualization({
 
 // Load BPMN diagram
 // Try the "Center" type to fit the whole container and center the diagram
-mainBpmnVisualization.load(collapsedDiagram, { fit: { type: "None" } });
+mainBpmnVisualization.load(collapsedDiagram, { fit: { type: "Center", margin: 10 } });
 
 
 // Interaction
@@ -36,7 +36,7 @@ footer.innerText = `bpmn-visualization@${version.lib}`;
 
 
 /*TO BE IMPLEMENTED
-observe navigation and zooming and 
+observe navigation and zooming and
 update circle ripples and linearGradient if they were added*/
 
 var containerBpmn = document.querySelector("#main-bpmn-container");


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/assynour/icpm-demo-2022/fix/improve_compliance-rules_popover_management?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=assynour&repo=icpm-demo-2022&branch=fix/improve_compliance-rules_popover_management">VS Code</a>

<!-- open-in-codesandbox:complete -->


The popover weren't displayed anymore after we allow to display the content of the subprocess. This
is now fixed. In addition, configure 'tippy's sticky' settings correctly.

Update the cursor on the activity with 'compliance rules' violations to state that the activity is
clickable.
Manage the tippy instances (destroy on hide) and visual elements lifecycle.

In addition
  - center main diagram at load time
  - remove dead code
  - remove console log

Notice there are a lot of refactoring needed in the file. It will be managed later.